### PR TITLE
Fix imports to make mangos go get-able

### DIFF
--- a/compat/compat.go
+++ b/compat/compat.go
@@ -38,18 +38,18 @@ import (
 )
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/bus"
-	"bitbucket.org/gdamore/mangos/protocol/pair"
-	"bitbucket.org/gdamore/mangos/protocol/pub"
-	"bitbucket.org/gdamore/mangos/protocol/pull"
-	"bitbucket.org/gdamore/mangos/protocol/push"
-	"bitbucket.org/gdamore/mangos/protocol/rep"
-	"bitbucket.org/gdamore/mangos/protocol/req"
-	"bitbucket.org/gdamore/mangos/protocol/respondent"
-	"bitbucket.org/gdamore/mangos/protocol/sub"
-	"bitbucket.org/gdamore/mangos/protocol/surveyor"
-	"bitbucket.org/gdamore/mangos/transport/all"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/bus"
+	"github.com/gdamore/mangos/protocol/pair"
+	"github.com/gdamore/mangos/protocol/pub"
+	"github.com/gdamore/mangos/protocol/pull"
+	"github.com/gdamore/mangos/protocol/push"
+	"github.com/gdamore/mangos/protocol/rep"
+	"github.com/gdamore/mangos/protocol/req"
+	"github.com/gdamore/mangos/protocol/respondent"
+	"github.com/gdamore/mangos/protocol/sub"
+	"github.com/gdamore/mangos/protocol/surveyor"
+	"github.com/gdamore/mangos/transport/all"
 )
 
 // Domain is the socket domain or address family.  We use it to indicate

--- a/examples/bus/bus.go
+++ b/examples/bus/bus.go
@@ -31,10 +31,10 @@
 package main
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/bus"
-	"bitbucket.org/gdamore/mangos/transport/ipc"
-	"bitbucket.org/gdamore/mangos/transport/tcp"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/bus"
+	"github.com/gdamore/mangos/transport/ipc"
+	"github.com/gdamore/mangos/transport/tcp"
 	"fmt"
 	"os"
 	"time"

--- a/examples/pair/pair.go
+++ b/examples/pair/pair.go
@@ -27,10 +27,10 @@
 package main
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/pair"
-	"bitbucket.org/gdamore/mangos/transport/ipc"
-	"bitbucket.org/gdamore/mangos/transport/tcp"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/pair"
+	"github.com/gdamore/mangos/transport/ipc"
+	"github.com/gdamore/mangos/transport/tcp"
 	"fmt"
 	"os"
 	"time"

--- a/examples/pipeline/pipeline.go
+++ b/examples/pipeline/pipeline.go
@@ -27,11 +27,11 @@
 package main
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/pull"
-	"bitbucket.org/gdamore/mangos/protocol/push"
-	"bitbucket.org/gdamore/mangos/transport/ipc"
-	"bitbucket.org/gdamore/mangos/transport/tcp"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/pull"
+	"github.com/gdamore/mangos/protocol/push"
+	"github.com/gdamore/mangos/transport/ipc"
+	"github.com/gdamore/mangos/transport/tcp"
 	"fmt"
 	"os"
 )

--- a/examples/pubsub/pubsub.go
+++ b/examples/pubsub/pubsub.go
@@ -29,11 +29,11 @@
 package main
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/pub"
-	"bitbucket.org/gdamore/mangos/protocol/sub"
-	"bitbucket.org/gdamore/mangos/transport/ipc"
-	"bitbucket.org/gdamore/mangos/transport/tcp"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/pub"
+	"github.com/gdamore/mangos/protocol/sub"
+	"github.com/gdamore/mangos/transport/ipc"
+	"github.com/gdamore/mangos/transport/tcp"
 	"fmt"
 	"os"
 	"time"

--- a/examples/reqrep/reqrep.go
+++ b/examples/reqrep/reqrep.go
@@ -26,11 +26,11 @@
 package main
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/rep"
-	"bitbucket.org/gdamore/mangos/protocol/req"
-	"bitbucket.org/gdamore/mangos/transport/ipc"
-	"bitbucket.org/gdamore/mangos/transport/tcp"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/rep"
+	"github.com/gdamore/mangos/protocol/req"
+	"github.com/gdamore/mangos/transport/ipc"
+	"github.com/gdamore/mangos/transport/tcp"
 	"fmt"
 	"os"
 	"time"

--- a/examples/survey/survey.go
+++ b/examples/survey/survey.go
@@ -29,11 +29,11 @@
 package main
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/respondent"
-	"bitbucket.org/gdamore/mangos/protocol/surveyor"
-	"bitbucket.org/gdamore/mangos/transport/ipc"
-	"bitbucket.org/gdamore/mangos/transport/tcp"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/respondent"
+	"github.com/gdamore/mangos/protocol/surveyor"
+	"github.com/gdamore/mangos/transport/ipc"
+	"github.com/gdamore/mangos/transport/tcp"
 	"fmt"
 	"os"
 	"time"

--- a/macat/macat.go
+++ b/macat/macat.go
@@ -30,19 +30,19 @@ import (
 )
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/bus"
-	"bitbucket.org/gdamore/mangos/protocol/pair"
-	"bitbucket.org/gdamore/mangos/protocol/pub"
-	"bitbucket.org/gdamore/mangos/protocol/pull"
-	"bitbucket.org/gdamore/mangos/protocol/push"
-	"bitbucket.org/gdamore/mangos/protocol/rep"
-	"bitbucket.org/gdamore/mangos/protocol/req"
-	"bitbucket.org/gdamore/mangos/protocol/respondent"
-	"bitbucket.org/gdamore/mangos/protocol/star"
-	"bitbucket.org/gdamore/mangos/protocol/sub"
-	"bitbucket.org/gdamore/mangos/protocol/surveyor"
-	"bitbucket.org/gdamore/mangos/transport/all"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/bus"
+	"github.com/gdamore/mangos/protocol/pair"
+	"github.com/gdamore/mangos/protocol/pub"
+	"github.com/gdamore/mangos/protocol/pull"
+	"github.com/gdamore/mangos/protocol/push"
+	"github.com/gdamore/mangos/protocol/rep"
+	"github.com/gdamore/mangos/protocol/req"
+	"github.com/gdamore/mangos/protocol/respondent"
+	"github.com/gdamore/mangos/protocol/star"
+	"github.com/gdamore/mangos/protocol/sub"
+	"github.com/gdamore/mangos/protocol/surveyor"
+	"github.com/gdamore/mangos/transport/all"
 	"github.com/droundy/goopt"
 )
 

--- a/protocol/bus/bus.go
+++ b/protocol/bus/bus.go
@@ -17,7 +17,7 @@
 package bus
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"encoding/binary"
 	"sync"
 )

--- a/protocol/pair/pair.go
+++ b/protocol/pair/pair.go
@@ -17,7 +17,7 @@
 package pair
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"sync"
 )
 

--- a/protocol/pub/pub.go
+++ b/protocol/pub/pub.go
@@ -18,7 +18,7 @@
 package pub
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"sync"
 )
 

--- a/protocol/pull/pull.go
+++ b/protocol/pull/pull.go
@@ -17,7 +17,7 @@
 package pull
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 )
 
 type pull struct {

--- a/protocol/push/push.go
+++ b/protocol/push/push.go
@@ -17,7 +17,7 @@
 package push
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 )
 
 type push struct {

--- a/protocol/rep/rep.go
+++ b/protocol/rep/rep.go
@@ -17,7 +17,7 @@
 package rep
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"encoding/binary"
 	"sync"
 )

--- a/protocol/req/req.go
+++ b/protocol/req/req.go
@@ -17,7 +17,7 @@
 package req
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"encoding/binary"
 	"sync"
 	"time"

--- a/protocol/respondent/respondent.go
+++ b/protocol/respondent/respondent.go
@@ -17,7 +17,7 @@
 package respondent
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"encoding/binary"
 	"sync"
 )

--- a/protocol/star/star.go
+++ b/protocol/star/star.go
@@ -23,7 +23,7 @@
 package star
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"sync"
 )
 

--- a/protocol/sub/sub.go
+++ b/protocol/sub/sub.go
@@ -19,7 +19,7 @@
 package sub
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"bytes"
 	"sync"
 )

--- a/protocol/surveyor/surveyor.go
+++ b/protocol/surveyor/surveyor.go
@@ -17,7 +17,7 @@
 package surveyor
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"encoding/binary"
 	"sync"
 	"time"

--- a/test/benchmark_test.go
+++ b/test/benchmark_test.go
@@ -15,11 +15,11 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/pair"
-	"bitbucket.org/gdamore/mangos/protocol/rep"
-	"bitbucket.org/gdamore/mangos/protocol/req"
-	"bitbucket.org/gdamore/mangos/transport/all"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/pair"
+	"github.com/gdamore/mangos/protocol/rep"
+	"github.com/gdamore/mangos/protocol/req"
+	"github.com/gdamore/mangos/transport/all"
 	"runtime"
 	"strings"
 	"testing"

--- a/test/bus_test.go
+++ b/test/bus_test.go
@@ -15,8 +15,8 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/bus"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/bus"
 	"encoding/binary"
 	"testing"
 )

--- a/test/common_test.go
+++ b/test/common_test.go
@@ -16,9 +16,9 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/transport/all"
-	"bitbucket.org/gdamore/mangos/transport/tlstcp"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/transport/all"
+	"github.com/gdamore/mangos/transport/tlstcp"
 	"bytes"
 	"encoding/binary"
 	"fmt"

--- a/test/device_test.go
+++ b/test/device_test.go
@@ -15,14 +15,14 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/pair"
-	"bitbucket.org/gdamore/mangos/protocol/rep"
-	"bitbucket.org/gdamore/mangos/protocol/req"
-	"bitbucket.org/gdamore/mangos/transport/inproc"
-	"bitbucket.org/gdamore/mangos/transport/ipc"
-	"bitbucket.org/gdamore/mangos/transport/tcp"
-	"bitbucket.org/gdamore/mangos/transport/tlstcp"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/pair"
+	"github.com/gdamore/mangos/protocol/rep"
+	"github.com/gdamore/mangos/protocol/req"
+	"github.com/gdamore/mangos/transport/inproc"
+	"github.com/gdamore/mangos/transport/ipc"
+	"github.com/gdamore/mangos/transport/tcp"
+	"github.com/gdamore/mangos/transport/tlstcp"
 	"testing"
 )
 

--- a/test/inproc_test.go
+++ b/test/inproc_test.go
@@ -15,8 +15,8 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/transport/inproc"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/transport/inproc"
 	"bytes"
 	"testing"
 	"time"

--- a/test/ipc_test.go
+++ b/test/ipc_test.go
@@ -15,8 +15,8 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/transport/ipc"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/transport/ipc"
 	"bytes"
 	"runtime"
 	"testing"

--- a/test/pair_test.go
+++ b/test/pair_test.go
@@ -15,8 +15,8 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/pair"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/pair"
 	"testing"
 )
 

--- a/test/pubsub_test.go
+++ b/test/pubsub_test.go
@@ -15,9 +15,9 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/pub"
-	"bitbucket.org/gdamore/mangos/protocol/sub"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/pub"
+	"github.com/gdamore/mangos/protocol/sub"
 	"bytes"
 	"testing"
 )

--- a/test/push_test.go
+++ b/test/push_test.go
@@ -15,9 +15,9 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/pull"
-	"bitbucket.org/gdamore/mangos/protocol/push"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/pull"
+	"github.com/gdamore/mangos/protocol/push"
 	"testing"
 )
 

--- a/test/reqrep_test.go
+++ b/test/reqrep_test.go
@@ -15,9 +15,9 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/rep"
-	"bitbucket.org/gdamore/mangos/protocol/req"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/rep"
+	"github.com/gdamore/mangos/protocol/req"
 	"testing"
 )
 

--- a/test/star_test.go
+++ b/test/star_test.go
@@ -15,9 +15,9 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/star"
-	"bitbucket.org/gdamore/mangos/transport/tcp"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/star"
+	"github.com/gdamore/mangos/transport/tcp"
 	"math/rand"
 	"testing"
 	"time"

--- a/test/survey_test.go
+++ b/test/survey_test.go
@@ -15,9 +15,9 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/respondent"
-	"bitbucket.org/gdamore/mangos/protocol/surveyor"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/respondent"
+	"github.com/gdamore/mangos/protocol/surveyor"
 	"encoding/binary"
 	"testing"
 	"time"

--- a/test/tcp_test.go
+++ b/test/tcp_test.go
@@ -15,8 +15,8 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/transport/tcp"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/transport/tcp"
 	"bytes"
 	"testing"
 	"time"

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -15,10 +15,10 @@
 package test
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/protocol/rep"
-	"bitbucket.org/gdamore/mangos/protocol/req"
-	"bitbucket.org/gdamore/mangos/transport/tlstcp"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/protocol/rep"
+	"github.com/gdamore/mangos/protocol/req"
+	"github.com/gdamore/mangos/transport/tlstcp"
 	"bytes"
 	"crypto/tls"
 	"testing"

--- a/transport/all/all.go
+++ b/transport/all/all.go
@@ -18,11 +18,11 @@
 package all
 
 import (
-	"bitbucket.org/gdamore/mangos"
-	"bitbucket.org/gdamore/mangos/transport/inproc"
-	"bitbucket.org/gdamore/mangos/transport/ipc"
-	"bitbucket.org/gdamore/mangos/transport/tcp"
-	"bitbucket.org/gdamore/mangos/transport/tlstcp"
+	"github.com/gdamore/mangos"
+	"github.com/gdamore/mangos/transport/inproc"
+	"github.com/gdamore/mangos/transport/ipc"
+	"github.com/gdamore/mangos/transport/tcp"
+	"github.com/gdamore/mangos/transport/tlstcp"
 )
 
 // AddTransports adds all known transports to the given socket.

--- a/transport/inproc/inproc.go
+++ b/transport/inproc/inproc.go
@@ -16,7 +16,7 @@
 package inproc
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"sync"
 )
 

--- a/transport/ipc/ipc.go
+++ b/transport/ipc/ipc.go
@@ -16,7 +16,7 @@
 package ipc
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"net"
 )
 

--- a/transport/tcp/tcp.go
+++ b/transport/tcp/tcp.go
@@ -16,7 +16,7 @@
 package tcp
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"net"
 )
 

--- a/transport/tlstcp/tlstcp.go
+++ b/transport/tlstcp/tlstcp.go
@@ -16,7 +16,7 @@
 package tlstcp
 
 import (
-	"bitbucket.org/gdamore/mangos"
+	"github.com/gdamore/mangos"
 	"crypto/tls"
 	"net"
 )


### PR DESCRIPTION
This updates the import paths to reflect the repo's new home on github.
