### PR TITLE
Buffer the publisher endpoint channel

### DIFF
--- a/protocol/pub/pub.go
+++ b/protocol/pub/pub.go
@@ -83,7 +83,7 @@ func (p *pub) sender() {
 }
 
 func (p *pub) AddEndpoint(ep mangos.Endpoint) {
-	pe := &pubEp{ep: ep, sock: p.sock, q: make(chan *mangos.Message)}
+	pe := &pubEp{ep: ep, sock: p.sock, q: make(chan *mangos.Message, 5)}
 	p.Lock()
 	p.eps[ep.GetID()] = pe
 	p.Unlock()


### PR DESCRIPTION
This solves the problem described here: https://gist.github.com/tylertreat/72dd72a5b2ed0251443f
The problem is publisher messages are dropped because of artificial backpressure due to the
use of an unbuffered channel. Adding a small buffer alleviates the problem.
