### PR TITLE
mangos: use canonical import path

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -23,4 +23,4 @@
 //
 // For more information, see www.nanomsg.org.
 //
-package mangos
+package mangos // import "github.com/go-mangos/mangos"


### PR DESCRIPTION
specify a canonical import path pointing at the new mangos repo location.
This will make errors less confusing for people updating their local repo, cloned before the move from gdamore/mangos to go-mangos/mangos.