### PR TITLE
fixes #201 Refactoring - make Protoxxx a type

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -92,12 +92,12 @@ func (p *conn) Send(msg *Message) error {
 }
 
 // LocalProtocol returns our local protocol number.
-func (p *conn) LocalProtocol() uint16 {
+func (p *conn) LocalProtocol() ProtocolNumber {
 	return p.proto.Number()
 }
 
 // RemoteProtocol returns our peer's protocol number.
-func (p *conn) RemoteProtocol() uint16 {
+func (p *conn) RemoteProtocol() ProtocolNumber {
 	return p.proto.PeerNumber()
 }
 
@@ -207,7 +207,7 @@ type connHeader struct {
 	S       byte // 'S'
 	P       byte // 'P'
 	Version byte // only zero at present
-	Proto   uint16
+	Proto   ProtocolNumber
 	Rsvd    uint16 // always zero at present
 }
 

--- a/pipe.go
+++ b/pipe.go
@@ -141,11 +141,11 @@ func (p *pipe) IsServer() bool {
 	return p.l != nil
 }
 
-func (p *pipe) LocalProtocol() uint16 {
+func (p *pipe) LocalProtocol() ProtocolNumber {
 	return p.pipe.LocalProtocol()
 }
 
-func (p *pipe) RemoteProtocol() uint16 {
+func (p *pipe) RemoteProtocol() ProtocolNumber {
 	return p.pipe.RemoteProtocol()
 }
 

--- a/port.go
+++ b/port.go
@@ -43,10 +43,10 @@ type Port interface {
 	IsClient() bool
 
 	// LocalProtocol returns the local protocol number.
-	LocalProtocol() uint16
+	LocalProtocol() ProtocolNumber
 
 	// RemoteProtocol returns the remote protocol number.
-	RemoteProtocol() uint16
+	RemoteProtocol() ProtocolNumber
 
 	// Dialer returns the dialer for this Port, or nil if a server.
 	Dialer() Dialer

--- a/protocol.go
+++ b/protocol.go
@@ -63,13 +63,13 @@ type Protocol interface {
 
 	// ProtocolNumber returns a 16-bit value for the protocol number,
 	// as assigned by the SP governing body. (IANA?)
-	Number() uint16
+	Number() ProtocolNumber
 
 	// Name returns our name.
 	Name() string
 
 	// PeerNumber() returns a 16-bit number for our peer protocol.
-	PeerNumber() uint16
+	PeerNumber() ProtocolNumber
 
 	// PeerName() returns the name of our peer protocol.
 	PeerName() string
@@ -151,31 +151,33 @@ type ProtocolSocket interface {
 	SetSendError(error)
 }
 
-// Useful constants for protocol numbers.  Note that the major protocol number
-// is stored in the upper 12 bits, and the minor (subprotocol) is located in
-// the bottom 4 bits.
+// ProtocolNumber represents the (registered) number associated with a given protocol.
+type ProtocolNumber uint16
+
+// Well-known protocol numbers.  Note that the major protocol number is stored in the
+// upper 12 bits, and the minor (subprotocol) is located in the bottom 4 bits.
 const (
-	ProtoPair       = (1 * 16)
-	ProtoPub        = (2 * 16)
-	ProtoSub        = (2 * 16) + 1
-	ProtoReq        = (3 * 16)
-	ProtoRep        = (3 * 16) + 1
-	ProtoPush       = (5 * 16)
-	ProtoPull       = (5 * 16) + 1
-	ProtoSurveyor   = (6 * 16) + 2
-	ProtoRespondent = (6 * 16) + 3
-	ProtoBus        = (7 * 16)
+	ProtoPair       ProtocolNumber = (1 * 16)
+	ProtoPub        ProtocolNumber = (2 * 16)
+	ProtoSub        ProtocolNumber = (2 * 16) + 1
+	ProtoReq        ProtocolNumber = (3 * 16)
+	ProtoRep        ProtocolNumber = (3 * 16) + 1
+	ProtoPush       ProtocolNumber = (5 * 16)
+	ProtoPull       ProtocolNumber = (5 * 16) + 1
+	ProtoSurveyor   ProtocolNumber = (6 * 16) + 2
+	ProtoRespondent ProtocolNumber = (6 * 16) + 3
+	ProtoBus        ProtocolNumber = (7 * 16)
 
 	// Experimental Protocols - Use at Risk
 
-	ProtoStar = (100 * 16)
+	ProtoStar ProtocolNumber = (100 * 16)
 )
 
-// ProtocolName returns the name corresponding to a given protocol number.
+// String implements the fmt.Stringer interface for ProtocolNumber.
 // This is useful for transports like WebSocket, which use a text name
 // rather than the number in the handshake.
-func ProtocolName(number uint16) string {
-	names := map[uint16]string{
+func (p ProtocolNumber) String() string {
+	names := map[ProtocolNumber]string{
 		ProtoPair:       "pair",
 		ProtoPub:        "pub",
 		ProtoSub:        "sub",
@@ -186,7 +188,7 @@ func ProtocolName(number uint16) string {
 		ProtoSurveyor:   "surveyor",
 		ProtoRespondent: "respondent",
 		ProtoBus:        "bus"}
-	return names[number]
+	return names[p]
 }
 
 // ValidPeers returns true if the two sockets are capable of

--- a/protocol/bus/bus.go
+++ b/protocol/bus/bus.go
@@ -178,20 +178,20 @@ func (x *bus) RemoveEndpoint(ep mangos.Endpoint) {
 	x.Unlock()
 }
 
-func (*bus) Number() uint16 {
+func (*bus) Number() mangos.ProtocolNumber {
 	return mangos.ProtoBus
 }
 
-func (*bus) Name() string {
-	return "bus"
+func (x *bus) Name() string {
+	return x.Number().String()
 }
 
-func (*bus) PeerNumber() uint16 {
+func (*bus) PeerNumber() mangos.ProtocolNumber {
 	return mangos.ProtoBus
 }
 
-func (*bus) PeerName() string {
-	return "bus"
+func (x *bus) PeerName() string {
+	return x.PeerNumber().String()
 }
 
 func (x *bus) RecvHook(m *mangos.Message) bool {

--- a/protocol/pair/pair.go
+++ b/protocol/pair/pair.go
@@ -113,20 +113,20 @@ func (x *pair) RemoveEndpoint(ep mangos.Endpoint) {
 	x.Unlock()
 }
 
-func (*pair) Number() uint16 {
+func (*pair) Number() mangos.ProtocolNumber {
 	return mangos.ProtoPair
 }
 
-func (*pair) Name() string {
-	return "pair"
+func (x *pair) Name() string {
+	return x.Number().String()
 }
 
-func (*pair) PeerNumber() uint16 {
+func (*pair) PeerNumber() mangos.ProtocolNumber {
 	return mangos.ProtoPair
 }
 
-func (*pair) PeerName() string {
-	return "pair"
+func (x *pair) PeerName() string {
+	return x.PeerNumber().String()
 }
 
 func (x *pair) SetOption(name string, v interface{}) error {

--- a/protocol/pub/pub.go
+++ b/protocol/pub/pub.go
@@ -139,20 +139,20 @@ func (p *pub) RemoveEndpoint(ep mangos.Endpoint) {
 	}
 }
 
-func (*pub) Number() uint16 {
+func (*pub) Number() mangos.ProtocolNumber {
 	return mangos.ProtoPub
 }
 
-func (*pub) PeerNumber() uint16 {
+func (*pub) PeerNumber() mangos.ProtocolNumber {
 	return mangos.ProtoSub
 }
 
-func (*pub) Name() string {
-	return "pub"
+func (p *pub) Name() string {
+	return p.Number().String()
 }
 
-func (*pub) PeerName() string {
-	return "sub"
+func (p *pub) PeerName() string {
+	return p.PeerNumber().String()
 }
 
 func (p *pub) SetOption(name string, v interface{}) error {

--- a/protocol/pull/pull.go
+++ b/protocol/pull/pull.go
@@ -52,20 +52,20 @@ func (x *pull) receiver(ep mangos.Endpoint) {
 	}
 }
 
-func (*pull) Number() uint16 {
+func (*pull) Number() mangos.ProtocolNumber {
 	return mangos.ProtoPull
 }
 
-func (*pull) PeerNumber() uint16 {
+func (*pull) PeerNumber() mangos.ProtocolNumber {
 	return mangos.ProtoPush
 }
 
-func (*pull) Name() string {
-	return "pull"
+func (x *pull) Name() string {
+	return x.Number().String()
 }
 
-func (*pull) PeerName() string {
-	return "push"
+func (x *pull) PeerName() string {
+	return x.PeerNumber().String()
 }
 
 func (x *pull) AddEndpoint(ep mangos.Endpoint) {

--- a/protocol/push/push.go
+++ b/protocol/push/push.go
@@ -67,20 +67,20 @@ func (x *push) sender(ep *pushEp) {
 	}
 }
 
-func (*push) Number() uint16 {
+func (*push) Number() mangos.ProtocolNumber {
 	return mangos.ProtoPush
 }
 
-func (*push) PeerNumber() uint16 {
+func (*push) PeerNumber() mangos.ProtocolNumber {
 	return mangos.ProtoPull
 }
 
-func (*push) Name() string {
-	return "push"
+func (x *push) Name() string {
+	return x.Number().String()
 }
 
-func (*push) PeerName() string {
-	return "pull"
+func (x *push) PeerName() string {
+	return x.PeerNumber().String()
 }
 
 func (x *push) AddEndpoint(ep mangos.Endpoint) {

--- a/protocol/rep/rep.go
+++ b/protocol/rep/rep.go
@@ -174,20 +174,20 @@ func (r *rep) sender() {
 	}
 }
 
-func (*rep) Number() uint16 {
+func (*rep) Number() mangos.ProtocolNumber {
 	return mangos.ProtoRep
 }
 
-func (*rep) PeerNumber() uint16 {
+func (*rep) PeerNumber() mangos.ProtocolNumber {
 	return mangos.ProtoReq
 }
 
-func (*rep) Name() string {
-	return "rep"
+func (r *rep) Name() string {
+	return r.Number().String()
 }
 
-func (*rep) PeerName() string {
-	return "req"
+func (r *rep) PeerName() string {
+	return r.PeerNumber().String()
 }
 
 func (r *rep) AddEndpoint(ep mangos.Endpoint) {

--- a/protocol/req/req.go
+++ b/protocol/req/req.go
@@ -162,20 +162,20 @@ func (r *req) sender(pe *reqEp) {
 	}
 }
 
-func (*req) Number() uint16 {
+func (*req) Number() mangos.ProtocolNumber {
 	return mangos.ProtoReq
 }
 
-func (*req) PeerNumber() uint16 {
+func (*req) PeerNumber() mangos.ProtocolNumber {
 	return mangos.ProtoRep
 }
 
-func (*req) Name() string {
-	return "req"
+func (r *req) Name() string {
+	return r.Number().String()
 }
 
-func (*req) PeerName() string {
-	return "rep"
+func (r *req) PeerName() string {
+	return r.PeerNumber().String()
 }
 
 func (r *req) AddEndpoint(ep mangos.Endpoint) {

--- a/protocol/respondent/respondent.go
+++ b/protocol/respondent/respondent.go
@@ -230,20 +230,20 @@ func (x *resp) RemoveEndpoint(ep mangos.Endpoint) {
 	}
 }
 
-func (*resp) Number() uint16 {
+func (*resp) Number() mangos.ProtocolNumber {
 	return mangos.ProtoRespondent
 }
 
-func (*resp) PeerNumber() uint16 {
+func (*resp) PeerNumber() mangos.ProtocolNumber {
 	return mangos.ProtoSurveyor
 }
 
-func (*resp) Name() string {
-	return "respondent"
+func (x *resp) Name() string {
+	return x.Number().String()
 }
 
-func (*resp) PeerName() string {
-	return "surveyor"
+func (x *resp) PeerName() string {
+	return x.PeerNumber().String()
 }
 
 func (x *resp) SetOption(name string, v interface{}) error {

--- a/protocol/star/star.go
+++ b/protocol/star/star.go
@@ -193,20 +193,20 @@ func (x *star) RemoveEndpoint(ep mangos.Endpoint) {
 	x.Unlock()
 }
 
-func (*star) Number() uint16 {
+func (*star) Number() mangos.ProtocolNumber {
 	return mangos.ProtoStar
 }
 
-func (*star) PeerNumber() uint16 {
+func (*star) PeerNumber() mangos.ProtocolNumber {
 	return mangos.ProtoStar
 }
 
-func (*star) Name() string {
-	return "star"
+func (x *star) Name() string {
+	return x.Number().String()
 }
 
-func (*star) PeerName() string {
-	return "star"
+func (x *star) PeerName() string {
+	return x.PeerNumber().String()
 }
 
 func (x *star) SetOption(name string, v interface{}) error {

--- a/protocol/sub/sub.go
+++ b/protocol/sub/sub.go
@@ -80,20 +80,20 @@ func (s *sub) receiver(ep mangos.Endpoint) {
 	}
 }
 
-func (*sub) Number() uint16 {
+func (*sub) Number() mangos.ProtocolNumber {
 	return mangos.ProtoSub
 }
 
-func (*sub) PeerNumber() uint16 {
+func (*sub) PeerNumber() mangos.ProtocolNumber {
 	return mangos.ProtoPub
 }
 
-func (*sub) Name() string {
-	return "sub"
+func (s *sub) Name() string {
+	return s.Number().String()
 }
 
-func (*sub) PeerName() string {
-	return "pub"
+func (s *sub) PeerName() string {
+	return s.PeerNumber().String()
 }
 
 func (s *sub) AddEndpoint(ep mangos.Endpoint) {

--- a/protocol/surveyor/surveyor.go
+++ b/protocol/surveyor/surveyor.go
@@ -166,20 +166,20 @@ func (x *surveyor) RemoveEndpoint(ep mangos.Endpoint) {
 	}
 }
 
-func (*surveyor) Number() uint16 {
+func (*surveyor) Number() mangos.ProtocolNumber {
 	return mangos.ProtoSurveyor
 }
 
-func (*surveyor) PeerNumber() uint16 {
+func (*surveyor) PeerNumber() mangos.ProtocolNumber {
 	return mangos.ProtoRespondent
 }
 
-func (*surveyor) Name() string {
-	return "surveyor"
+func (x *surveyor) Name() string {
+	return x.Number().String()
 }
 
-func (*surveyor) PeerName() string {
-	return "respondent"
+func (x *surveyor) PeerName() string {
+	return x.PeerNumber().String()
 }
 
 func (x *surveyor) SendHook(m *mangos.Message) bool {

--- a/transport.go
+++ b/transport.go
@@ -50,12 +50,12 @@ type Pipe interface {
 	// LocalProtocol returns the 16-bit SP protocol number used by the
 	// local side.  This will normally be sent to the peer during
 	// connection establishment.
-	LocalProtocol() uint16
+	LocalProtocol() ProtocolNumber
 
 	// RemoteProtocol returns the 16-bit SP protocol number used by the
 	// remote side.  This will normally be received from the peer during
 	// connection establishment.
-	RemoteProtocol() uint16
+	RemoteProtocol() ProtocolNumber
 
 	// IsOpen returns true if the underlying connection is open.
 	IsOpen() bool

--- a/transport/inproc/inproc.go
+++ b/transport/inproc/inproc.go
@@ -113,11 +113,11 @@ func (p *inproc) Send(m *mangos.Message) error {
 	}
 }
 
-func (p *inproc) LocalProtocol() uint16 {
+func (p *inproc) LocalProtocol() mangos.ProtocolNumber {
 	return p.proto.Number()
 }
 
-func (p *inproc) RemoteProtocol() uint16 {
+func (p *inproc) RemoteProtocol() mangos.ProtocolNumber {
 	return p.proto.PeerNumber()
 }
 

--- a/transport/ws/ws.go
+++ b/transport/ws/ws.go
@@ -137,11 +137,11 @@ func (w *wsPipe) Send(m *mangos.Message) error {
 	return nil
 }
 
-func (w *wsPipe) LocalProtocol() uint16 {
+func (w *wsPipe) LocalProtocol() mangos.ProtocolNumber {
 	return w.proto.Number()
 }
 
-func (w *wsPipe) RemoteProtocol() uint16 {
+func (w *wsPipe) RemoteProtocol() mangos.ProtocolNumber {
 	return w.proto.PeerNumber()
 }
 


### PR DESCRIPTION
Revised (v3); this time without changing the interface -- keeping the `Name()` and `PeerName()` methods.