### PR TITLE
tlstcp anonymous TCP port binding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Dustin Hiatt <hiatt.dustin@gmail.com>
 wenfang <wangwenfang@gmail.com>
 Anner van Hardenbroek <anner@xsnews.nl>
 Gerrit Renker <Gerrit.Renker@ctl.io>
+Rene Kaufmann <kaufmann.r@gmail.com>

--- a/transport/tlstcp/tlstcp.go
+++ b/transport/tlstcp/tlstcp.go
@@ -108,13 +108,13 @@ func (d *dialer) GetOption(n string) (interface{}, error) {
 type listener struct {
 	sock     mangos.Socket
 	addr     *net.TCPAddr
+	bound    net.Addr
 	listener *net.TCPListener
 	opts     options
 	config   *tls.Config
 }
 
 func (l *listener) Listen() error {
-
 	var err error
 	v, ok := l.opts[mangos.OptionTLSConfig]
 	if !ok {
@@ -131,10 +131,16 @@ func (l *listener) Listen() error {
 	if l.listener, err = net.ListenTCP("tcp", l.addr); err != nil {
 		return err
 	}
+
+	l.bound = l.listener.Addr()
+
 	return nil
 }
 
 func (l *listener) Address() string {
+	if b := l.bound; b != nil {
+		return "tls+tcp://" + b.String()
+	}
 	return "tls+tcp://" + l.addr.String()
 }
 


### PR DESCRIPTION
before this listener.Address() always returned addr:0 and not the anonymous port. 