### PR TITLE
fixes #260 Assure TLS handshake completes before storing state

### DIFF
--- a/transport/tlstcp/tlstcp.go
+++ b/transport/tlstcp/tlstcp.go
@@ -88,6 +88,10 @@ func (d *dialer) Dial() (mangos.Pipe, error) {
 		config = v.(*tls.Config)
 	}
 	conn := tls.Client(tconn, config)
+	if err = conn.Handshake(); err != nil {
+		conn.Close()
+		return nil, err
+	}
 	return mangos.NewConnPipe(conn, d.sock,
 		mangos.PropTLSConnState, conn.ConnectionState())
 }


### PR DESCRIPTION
Race condition in my code stemmed from handshake sometime occurring before storing state as prop and sometimes after. This assures that it is done first and PropTLSConnState reflects and accurate status.