### PR TITLE
Fix deadlock and connection leaking when Dialing and closing multiple times for a socket. Al…

### DIFF
--- a/core.go
+++ b/core.go
@@ -620,6 +620,7 @@ func (d *dialer) dialer() {
 			rtime = d.sock.reconntime
 			d.sock.Lock()
 			if d.closed {
+				d.sock.Unlock()
 				p.Close()
 				return
 			}
@@ -636,8 +637,14 @@ func (d *dialer) dialer() {
 		// we're redialing here
 		select {
 		case <-d.closeq: // dialer closed
+			if p != nil {
+				p.Close()
+			}
 			return
 		case <-d.sock.closeq: // exit if parent socket closed
+			if p != nil {
+				p.Close()
+			}
 			return
 		case <-time.After(rtime):
 			if rtmax > 0 {

--- a/transport/inproc/inproc.go
+++ b/transport/inproc/inproc.go
@@ -31,6 +31,7 @@ type inproc struct {
 	proto  mangos.Protocol
 	addr   addr
 	peer   *inproc
+	sync.Mutex
 }
 
 type addr string
@@ -122,7 +123,11 @@ func (p *inproc) RemoteProtocol() uint16 {
 }
 
 func (p *inproc) Close() error {
-	close(p.closeq)
+	p.Lock()
+	defer p.Unlock()
+	if p.IsOpen() {
+		close(p.closeq)
+	}
 	return nil
 }
 

--- a/transport/ws/ws.go
+++ b/transport/ws/ws.go
@@ -130,6 +130,7 @@ type wsPipe struct {
 	props map[string]interface{}
 	iswss bool
 	dtype int
+	sync.Mutex
 }
 
 type wsTran int
@@ -177,9 +178,13 @@ func (w *wsPipe) RemoteProtocol() uint16 {
 }
 
 func (w *wsPipe) Close() error {
-	w.open = false
-	w.ws.Close()
-	w.wg.Done()
+	w.Lock()
+	defer w.Unlock()
+	if w.IsOpen() {
+		w.open = false
+		w.ws.Close()
+		w.wg.Done()
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Background
I have a socket which connects to multiple endpoints. From time to time, depending on the availability of the endpoint or presence of new endpoints, I have my socket disconnect from/connect to endpoints.

Not sure if this is the best way (I am open to suggestions). On the socket I create a new dialer. and keep a map of endpoints to dialers. When I need to disconnect I retrieve the dialer from the map by endpoint and call Close().

## Problem
The first problem I encountered was the leak of connections **most** time I did this (See Appendix A). So I wrote a simple program that does two things:
i) Create new dialer, Dial()
ii) Close()
iii) Repeat. And check for leaks.

I saw leaks however they weren't consistent so I thought it could be one of those weird race-timey conditions. So I decided to add a sleep between my Close()s and Dial()s. When I did this I found that the program hung indefinitely.

## Fix
1.) The fix I'm putting in is to make sure we Unlock() the socket if we are reconnecting and the dialer is already closed.
2.) If the dialer is closed make sure we also close it's pipeDialer. Because of this I had to add some lock guarded checks to IsOpen for 'websockets' and 'inproc' transports.

## Appendix A
```
sudo lsof -i | grep {process_name}
TCP localhost:52169->localhost:33033 (ESTABLISHED)
TCP localhost:52135->localhost:33033 (ESTABLISHED)
TCP localhost:33033->localhost:52135 (ESTABLISHED)
TCP localhost:52136->localhost:33031 (ESTABLISHED)
TCP localhost:52137->localhost:33032 (ESTABLISHED)
TCP localhost:33031->localhost:52136 (ESTABLISHED)
TCP localhost:33032->localhost:52137 (ESTABLISHED)
TCP localhost:52170->localhost:33031 (ESTABLISHED)
TCP localhost:52171->localhost:33032 (ESTABLISHED)
TCP localhost:33031->localhost:52170 (ESTABLISHED)
TCP localhost:33032->localhost:52171 (ESTABLISHED)
TCP localhost:33033->localhost:52169 (ESTABLISHED)
TCP localhost:52178->localhost:33033 (ESTABLISHED)
TCP localhost:52179->localhost:33031 (ESTABLISHED)
TCP localhost:52180->localhost:33032 (ESTABLISHED)
TCP localhost:33033->localhost:52178 (ESTABLISHED)
TCP localhost:33031->localhost:52179 (ESTABLISHED)
TCP localhost:33032->localhost:52180 (ESTABLISHED)
```
