### PR TITLE
fixes #2 Add support for Named Pipes on Windows

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Mangos Authors
+// Copyright 2018 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -143,69 +143,6 @@ func NewConnPipe(c net.Conn, sock Socket, props ...interface{}) (Pipe, error) {
 	}
 
 	return p, nil
-}
-
-// NewConnPipeIPC allocates a new Pipe using the IPC exchange protocol.
-func NewConnPipeIPC(c net.Conn, sock Socket, props ...interface{}) (Pipe, error) {
-	p := &connipc{conn: conn{c: c, proto: sock.GetProtocol(), sock: sock}}
-
-	if err := p.handshake(props); err != nil {
-		return nil, err
-	}
-
-	return p, nil
-}
-
-func (p *connipc) Send(msg *Message) error {
-
-	l := uint64(len(msg.Header) + len(msg.Body))
-	one := [1]byte{1}
-	var err error
-
-	// send length header
-	if _, err = p.c.Write(one[:]); err != nil {
-		return err
-	}
-	if err = binary.Write(p.c, binary.BigEndian, l); err != nil {
-		return err
-	}
-	if _, err = p.c.Write(msg.Header); err != nil {
-		return err
-	}
-	// hope this works
-	if _, err = p.c.Write(msg.Body); err != nil {
-		return err
-	}
-	msg.Free()
-	return nil
-}
-
-func (p *connipc) Recv() (*Message, error) {
-
-	var sz int64
-	var err error
-	var msg *Message
-	var one [1]byte
-
-	if _, err = p.c.Read(one[:]); err != nil {
-		return nil, err
-	}
-	if err = binary.Read(p.c, binary.BigEndian, &sz); err != nil {
-		return nil, err
-	}
-
-	// Limit messages to the maximum receive value, if not
-	// unlimited.  This avoids a potential denaial of service.
-	if sz < 0 || (p.maxrx > 0 && sz > p.maxrx) {
-		return nil, ErrTooLong
-	}
-	msg = NewMessage(int(sz))
-	msg.Body = msg.Body[0:sz]
-	if _, err = io.ReadFull(p.c, msg.Body); err != nil {
-		msg.Free()
-		return nil, err
-	}
-	return msg, nil
 }
 
 // connHeader is exchanged during the initial handshake.

--- a/connipc_posix.go
+++ b/connipc_posix.go
@@ -1,0 +1,88 @@
+// +build !windows
+
+// Copyright 2018 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mangos
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+)
+
+// NewConnPipeIPC allocates a new Pipe using the IPC exchange protocol.
+func NewConnPipeIPC(c net.Conn, sock Socket, props ...interface{}) (Pipe, error) {
+	p := &connipc{conn: conn{c: c, proto: sock.GetProtocol(), sock: sock}}
+
+	if err := p.handshake(props); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+func (p *connipc) Send(msg *Message) error {
+
+	l := uint64(len(msg.Header) + len(msg.Body))
+	//	one := [1]byte{1}
+	var err error
+
+	// send length header
+	header := make([]byte, 9)
+	header[0] = 1
+	binary.BigEndian.PutUint64(header[1:], l)
+
+	if _, err = p.c.Write(header[:]); err != nil {
+		return err
+	}
+
+	if _, err = p.c.Write(msg.Header); err != nil {
+		return err
+	}
+	// hope this works
+	if _, err = p.c.Write(msg.Body); err != nil {
+		return err
+	}
+	msg.Free()
+	return nil
+}
+
+func (p *connipc) Recv() (*Message, error) {
+
+	var sz int64
+	var err error
+	var msg *Message
+	var one [1]byte
+
+	if _, err = p.c.Read(one[:]); err != nil {
+		return nil, err
+	}
+	if err = binary.Read(p.c, binary.BigEndian, &sz); err != nil {
+		return nil, err
+	}
+
+	// Limit messages to the maximum receive value, if not
+	// unlimited.  This avoids a potential denaial of service.
+	if sz < 0 || (p.maxrx > 0 && sz > p.maxrx) {
+		return nil, ErrTooLong
+	}
+	msg = NewMessage(int(sz))
+	msg.Body = msg.Body[0:sz]
+	if _, err = io.ReadFull(p.c, msg.Body); err != nil {
+		msg.Free()
+		return nil, err
+	}
+	return msg, nil
+}

--- a/connipc_windows.go
+++ b/connipc_windows.go
@@ -1,0 +1,87 @@
+// +build windows
+
+// Copyright 2018 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mangos
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+)
+
+// NewConnPipeIPC allocates a new Pipe using the IPC exchange protocol.
+func NewConnPipeIPC(c net.Conn, sock Socket, props ...interface{}) (Pipe, error) {
+	p := &connipc{conn: conn{c: c, proto: sock.GetProtocol(), sock: sock}}
+
+	if err := p.handshake(props); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+func (p *connipc) Send(msg *Message) error {
+
+	l := uint64(len(msg.Header) + len(msg.Body))
+	var err error
+
+	// On Windows, we have to put everything into a contiguous buffer.
+	// This is to workaround bugs in legacy libnanomsg.  Eventually we
+	// might do away with this logic, but only when legacy libnanomsg
+	// has been fixed.  This puts some pressure on the gc too, which
+	// makes me pretty sad.
+
+	// send length header
+	buf := make([]byte, 9, 9+l)
+	buf[0] = 1
+	binary.BigEndian.PutUint64(buf[1:], l)
+	buf = append(buf, msg.Header...)
+	buf = append(buf, msg.Body...)
+
+	if _, err = p.c.Write(buf[:]); err != nil {
+		return err
+	}
+	msg.Free()
+	return nil
+}
+
+func (p *connipc) Recv() (*Message, error) {
+
+	var sz int64
+	var err error
+	var msg *Message
+	var one [1]byte
+
+	if _, err = p.c.Read(one[:]); err != nil {
+		return nil, err
+	}
+	if err = binary.Read(p.c, binary.BigEndian, &sz); err != nil {
+		return nil, err
+	}
+
+	// Limit messages to the maximum receive value, if not
+	// unlimited.  This avoids a potential denaial of service.
+	if sz < 0 || (p.maxrx > 0 && sz > p.maxrx) {
+		return nil, ErrTooLong
+	}
+	msg = NewMessage(int(sz))
+	msg.Body = msg.Body[0:sz]
+	if _, err = io.ReadFull(p.c, msg.Body); err != nil {
+		msg.Free()
+		return nil, err
+	}
+	return msg, nil
+}

--- a/test/benchmark_test.go
+++ b/test/benchmark_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Mangos Authors
+// Copyright 2018 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -15,7 +15,6 @@
 package test
 
 import (
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -28,11 +27,6 @@ import (
 )
 
 func benchmarkReq(t *testing.B, url string, size int) {
-
-	if strings.HasPrefix(url, "ipc://") && runtime.GOOS == "windows" {
-		t.Skip("IPC not supported on Windows")
-		return
-	}
 
 	srvopts := make(map[string]interface{})
 	cliopts := make(map[string]interface{})
@@ -111,11 +105,6 @@ func benchmarkReq(t *testing.B, url string, size int) {
 
 func benchmarkPair(t *testing.B, url string, size int) {
 
-	if strings.HasPrefix(url, "ipc://") && runtime.GOOS == "windows" {
-		t.Skip("IPC not supported on Windows")
-		return
-	}
-
 	srvopts := make(map[string]interface{})
 	cliopts := make(map[string]interface{})
 
@@ -187,7 +176,7 @@ func benchmarkPair(t *testing.B, url string, size int) {
 
 var benchInpAddr = "inproc://benchmark_test"
 var benchTCPAddr = "tcp://127.0.0.1:33833"
-var benchIPCAddr = "ipc:///tmp/benchmark_test"
+var benchIPCAddr = "ipc://benchmark_test_sock"
 var benchTLSAddr = "tls+tcp://127.0.0.1:44844"
 var benchWSAddr = "ws://127.0.0.1:55855/BENCHMARK"
 var benchWSSAddr = "wss://127.0.0.1:55856/BENCHMARK"

--- a/test/common_test.go
+++ b/test/common_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Mangos Authors
+// Copyright 2018 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -583,11 +582,6 @@ func slowStart(t *testing.T, cases []TestCase) bool {
 // RunTests runs tests.
 func RunTests(t *testing.T, addr string, cases []TestCase) {
 
-	if strings.HasPrefix(addr, "ipc://") && runtime.GOOS == "windows" {
-		t.Skip("IPC not supported on Windows yet")
-		return
-	}
-
 	// We need to inject a slight bit of sleep to allow any sessions to
 	// drain before we close connections.
 	defer time.Sleep(50 * time.Millisecond)
@@ -629,7 +623,7 @@ func RunTests(t *testing.T, addr string, cases []TestCase) {
 var AddrTestTCP = "tcp://127.0.0.1:59093"
 
 // AddrTestIPC is a suitable IPC address for testing.
-var AddrTestIPC = "ipc:///tmp/MYTEST_IPC"
+var AddrTestIPC = "ipc://MYTEST_IPC_SOCK"
 
 // AddrTestInp is a suitable Inproc address for testing.
 var AddrTestInp = "inproc://MYTEST_INPROC"

--- a/test/device_test.go
+++ b/test/device_test.go
@@ -15,7 +15,6 @@
 package test
 
 import (
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -294,11 +293,7 @@ func TestDeviceLoopInp(t *testing.T) {
 }
 
 func TestDeviceLoopIPC(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("IPC not supported on Windows")
-	} else {
-		testDevLoop(t, AddrTestIPC)
-	}
+	testDevLoop(t, AddrTestIPC)
 }
 
 func TestDeviceLoopTLS(t *testing.T) {

--- a/transport/ipc/ipc_test.go
+++ b/transport/ipc/ipc_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Mangos Authors
+// Copyright 2018 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -21,12 +21,10 @@ import (
 	"github.com/go-mangos/mangos/test"
 )
 
-var tt = test.NewTranTest(NewTransport(), "ipc:///tmp/test1234")
+var tt = test.NewTranTest(NewTransport(), "ipc://test1234")
 
 func TestIpcListenAndAccept(t *testing.T) {
 	switch runtime.GOOS {
-	case "windows":
-		t.Skip("IPC not supported on Windows")
 	case "plan9":
 		t.Skip("IPC not supported on Plan9")
 	default:
@@ -36,8 +34,6 @@ func TestIpcListenAndAccept(t *testing.T) {
 
 func TestIpcDuplicateListen(t *testing.T) {
 	switch runtime.GOOS {
-	case "windows":
-		t.Skip("IPC not supported on Windows")
 	case "plan9":
 		t.Skip("IPC not supported on Plan9")
 	default:
@@ -47,8 +43,6 @@ func TestIpcDuplicateListen(t *testing.T) {
 
 func TestIpcConnRefused(t *testing.T) {
 	switch runtime.GOOS {
-	case "windows":
-		t.Skip("IPC not supported on Windows")
 	case "plan9":
 		t.Skip("IPC not supported on Plan9")
 	default:
@@ -58,8 +52,6 @@ func TestIpcConnRefused(t *testing.T) {
 
 func TestIpcSendRecv(t *testing.T) {
 	switch runtime.GOOS {
-	case "windows":
-		t.Skip("IPC not supported on Windows")
 	case "plan9":
 		t.Skip("IPC not supported on Plan9")
 	default:
@@ -69,8 +61,6 @@ func TestIpcSendRecv(t *testing.T) {
 
 func TestIpcAll(t *testing.T) {
 	switch runtime.GOOS {
-	case "windows":
-		t.Skip("IPC not supported on Windows")
 	case "plan9":
 		t.Skip("IPC not supported on Plan9")
 	default:

--- a/transport/ipc/ipc_unix.go
+++ b/transport/ipc/ipc_unix.go
@@ -1,3 +1,5 @@
+// +build !windows,!nacl,!plan9
+
 // Copyright 2015 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/transport/ipc/ipc_windows.go
+++ b/transport/ipc/ipc_windows.go
@@ -1,0 +1,234 @@
+// +build windows
+
+// Copyright 2018 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ipc implements the IPC transport on top of Windows Named Pipes.
+package ipc
+
+import (
+	"net"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/go-mangos/mangos"
+)
+
+// The options here are pretty specific to Windows Named Pipes.
+
+const (
+	// OptionSecurityDescriptor represents a Windows security
+	// descriptor in SDDL format (string).  This can only be set on
+	// a Listener, and must be set before the Listen routine
+	// is called.
+	OptionSecurityDescriptor = "WIN-IPC-SECURITY-DESCRIPTOR"
+
+	// OptionInputBufferSize represents the Windows Named Pipe
+	// input buffer size in bytes (type int32).  Default is 4096.
+	// This is only for Listeners, and must be set before the
+	// Listener is started.
+	OptionInputBufferSize = "WIN-IPC-INPUT-BUFFER-SIZE"
+
+	// OptionOutputBufferSize represents the Windows Named Pipe
+	// output buffer size in bytes (type int32).  Default is 4096.
+	// This is only for Listeners, and must be set before the
+	// Listener is started.
+	OptionOutputBufferSize = "WIN-IPC-OUTPUT-BUFFER-SIZE"
+)
+
+type pipeAddr string
+
+func (p pipeAddr) Network() string {
+	return "ipc"
+}
+
+func (p pipeAddr) String() string {
+	return string(p)
+}
+
+type dialer struct {
+	path string
+	sock mangos.Socket
+}
+
+// Dial implements the PipeDialer Dial method.
+func (d *dialer) Dial() (mangos.Pipe, error) {
+
+	conn, err := winio.DialPipe("\\\\.\\pipe\\"+d.path, nil)
+	if err != nil {
+		return nil, err
+	}
+	addr := pipeAddr(d.path)
+	return mangos.NewConnPipeIPC(conn, d.sock,
+		mangos.PropLocalAddr, addr, mangos.PropRemoteAddr, addr)
+}
+
+// SetOption implements a stub PipeDialer SetOption method.
+func (d *dialer) SetOption(n string, v interface{}) error {
+	return mangos.ErrBadOption
+}
+
+// GetOption implements a stub PipeDialer GetOption method.
+func (d *dialer) GetOption(n string) (interface{}, error) {
+	return nil, mangos.ErrBadOption
+}
+
+// listenerOptions is used for shared GetOption/SetOption logic for listeners.
+// We don't have dialer specific options at this point.
+type listenerOptions map[string]interface{}
+
+// GetOption retrieves an option value.
+func (o listenerOptions) get(name string) (interface{}, error) {
+	if o == nil {
+		return nil, mangos.ErrBadOption
+	}
+	v, ok := o[name]
+	if !ok {
+		return nil, mangos.ErrBadOption
+	}
+	return v, nil
+}
+
+// SetOption sets an option.  We have none, so just ErrBadOption.
+func (o listenerOptions) set(string, interface{}) error {
+	return mangos.ErrBadOption
+}
+
+type listener struct {
+	path     string
+	sock     mangos.Socket
+	listener net.Listener
+	config   winio.PipeConfig
+}
+
+// Listen implements the PipeListener Listen method.
+func (l *listener) Listen() error {
+	listener, err := winio.ListenPipe("\\\\.\\pipe\\"+l.path, &l.config)
+	if err != nil {
+		return err
+	}
+	l.listener = listener
+	return nil
+}
+
+func (l *listener) Address() string {
+	return "ipc://" + l.path
+}
+
+// Accept implements the the PipeListener Accept method.
+func (l *listener) Accept() (mangos.Pipe, error) {
+
+	conn, err := l.listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	addr := pipeAddr(l.path)
+	return mangos.NewConnPipeIPC(conn, l.sock,
+		mangos.PropLocalAddr, addr, mangos.PropRemoteAddr, addr)
+}
+
+// Close implements the PipeListener Close method.
+func (l *listener) Close() error {
+	if l.listener != nil {
+		l.listener.Close()
+	}
+	return nil
+}
+
+// SetOption implements a stub PipeListener SetOption method.
+func (l *listener) SetOption(name string, val interface{}) error {
+	switch name {
+	case OptionInputBufferSize:
+		switch v := val.(type) {
+		case int32:
+			l.config.InputBufferSize = v
+			return nil
+		default:
+			return mangos.ErrBadValue
+		}
+	case OptionOutputBufferSize:
+		switch v := val.(type) {
+		case int32:
+			l.config.OutputBufferSize = v
+			return nil
+		default:
+			return mangos.ErrBadValue
+		}
+	case OptionSecurityDescriptor:
+		switch v := val.(type) {
+		case string:
+			l.config.SecurityDescriptor = v
+			return nil
+		default:
+			return mangos.ErrBadValue
+		}
+	default:
+		return mangos.ErrBadOption
+	}
+}
+
+// GetOption implements a stub PipeListener GetOption method.
+func (l *listener) GetOption(name string) (interface{}, error) {
+	switch name {
+	case OptionInputBufferSize:
+		return l.config.InputBufferSize, nil
+	case OptionOutputBufferSize:
+		return l.config.OutputBufferSize, nil
+	case OptionSecurityDescriptor:
+		return l.config.SecurityDescriptor, nil
+	}
+	return nil, mangos.ErrBadOption
+}
+
+type ipcTran struct{}
+
+// Scheme implements the Transport Scheme method.
+func (t *ipcTran) Scheme() string {
+	return "ipc"
+}
+
+// NewDialer implements the Transport NewDialer method.
+func (t *ipcTran) NewDialer(addr string, sock mangos.Socket) (mangos.PipeDialer, error) {
+	var err error
+
+	if addr, err = mangos.StripScheme(t, addr); err != nil {
+		return nil, err
+	}
+
+	d := &dialer{sock: sock}
+	d.path = addr
+	return d, nil
+}
+
+// NewListener implements the Transport NewListener method.
+func (t *ipcTran) NewListener(addr string, sock mangos.Socket) (mangos.PipeListener, error) {
+	var err error
+	l := &listener{sock: sock}
+	l.config.OutputBufferSize = 4096
+	l.config.InputBufferSize = 4096
+	l.config.SecurityDescriptor = ""
+	l.config.MessageMode = false
+
+	if addr, err = mangos.StripScheme(t, addr); err != nil {
+		return nil, err
+	}
+
+	l.path = addr
+
+	return l, nil
+}
+
+// NewTransport allocates a new IPC transport.
+func NewTransport() mangos.Transport {
+	return &ipcTran{}
+}


### PR DESCRIPTION
This adds support for Windows Named Pipes as ipc:// URLs that are
compatible with nanomsg and NNG.

It also includes (untested) support for SecurityDescriptor and
InputBufferSize and OutputBufferSize tunables.   It is built on
the github.com/Microsoft/go-winio library.

Note that legacy libnanomsg (all versions 1.1.3 and earlier) is
very fragile in it's handling of IPC, and assumes that senders
will only send a single atomic write.  This assumption requires
us to make an extra data copy.  (Note that NNG has no such assumptions,
and we could easily dispense with the data copy for NNG.)